### PR TITLE
Fix for Incomplete ordering

### DIFF
--- a/selfbot/listener.py
+++ b/selfbot/listener.py
@@ -1,8 +1,9 @@
 from pyrogram import Client, filters
 from pyrogram.enums import MessageServiceType
 from pyrogram.types import Message
+import functools
 
-
+@functools.total_ordering
 class Listener:
     def __init__(
         self, mod: type, func: callable, event: str, filters: callable, priority: int
@@ -15,6 +16,10 @@ class Listener:
 
     def __lt__(self, other: "Listener") -> bool:
         return self.priority < other.priority
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Listener):
+            return NotImplemented
+        return self.priority == other.priority
 
 
 def handler(filters: callable, priority: int) -> callable:

--- a/selfbot/listener.py
+++ b/selfbot/listener.py
@@ -2,7 +2,8 @@ from pyrogram import Client, filters
 from pyrogram.enums import MessageServiceType
 from pyrogram.types import Message
 import functools
-
+import functools
+@functools.total_ordering
 @functools.total_ordering
 class Listener:
     def __init__(
@@ -15,6 +16,10 @@ class Listener:
         self.priority = priority
 
     def __lt__(self, other: "Listener") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Listener):
+            return NotImplemented
+        return self.priority == other.priority
         return self.priority < other.priority
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Listener):


### PR DESCRIPTION
The best fix is to ensure that all rich comparison operators are implemented so that instances of `Listener` behave as expected when using any of `<`, `<=`, `>`, or `>=`. The simplest way is to use Python's `functools.total_ordering` decorator, which automatically generates the missing comparison methods if you provide at least `__lt__` and `__eq__`. We need to:

- Import `functools` to use `total_ordering`.
- Implement the `__eq__` method in the `Listener` class (e.g., comparing by `priority` and possibly other relevant attributes).
- Decorate the `Listener` class with `@functools.total_ordering`.

All changes are to be made within `selfbot/listener.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._