### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/selfbot/modules/genai.py
+++ b/selfbot/modules/genai.py
@@ -126,7 +126,7 @@ class GenAI(Module):
                 self.data.append(text)
 
     async def respond(self, event: Update) -> None:
-        text, edit = "", None
+        edit = None
         if isinstance(event, ChosenInlineResult):
             text, edit = event.query, event.edit_message_text
         else:


### PR DESCRIPTION
The best fix is to remove the unnecessary initialization of `text` in line 129 of `respond`. Since `text` is immediately set in both branches, starting `text` as empty is redundant. Only `edit` is needed to be initialized to `None (edit = None)`, since it is conditionally defined.  
Action: Change line 129 from  
`text, edit = "", None`  
to  
`edit = None`.

No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._