### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/selfbot/modules/genai.py
+++ b/selfbot/modules/genai.py
@@ -126,7 +126,7 @@ class GenAI(Module):
                 self.data.append(text)
 
     async def respond(self, event: Update) -> None:
-        text, edit = "", None
+        text = ""
         if isinstance(event, ChosenInlineResult):
             text, edit = event.query, event.edit_message_text
         else:


### PR DESCRIPTION
To fix the problem, remove the unnecessary initial assignment of `edit = None` on line 129 in `respond`.  
- Change only line 129: remove `edit = None`, leaving just `text = ""`.
- No imports, methods, or other code changes are required.
- The function will remain correct because the next lines always assign to `edit` before using it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._