### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/selfbot/core/storage.py
+++ b/selfbot/core/storage.py
@@ -274,3 +274,4 @@ class PostgreStorage(Storage):
             value,
             self.name,
         )
+        return None


### PR DESCRIPTION
The best way to fix this issue is to ensure that all branches of the `_value` function have explicit return statements, even if only returning `None`. This removes ambiguity, makes clearest the function's contract, and resolves the CodeQL issue. Specifically, on the path where the function performs an update (i.e., not a "get"), an explicit `return None` should be added right after the update operation. This matches the implicit return but makes the intention and code flow clear. Only code you’ve provided can be changed, so we will append `return None` after the database update block at the end of the `_value` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._