### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/selfbot/modules/call.py
+++ b/selfbot/modules/call.py
@@ -51,7 +51,8 @@ class Call(Module):
     async def on_starting(self) -> None:
         if not load:
             self.logger.warning("PyTgCalls None")
-            return self.client.unload(self)
+            self.client.unload(self)
+            return
 
         self.client.call = PyTgCalls(self.client.app, 1, 15)
         self.logger.info("Starting PyTgCalls...")


### PR DESCRIPTION
To resolve the issue, remove the explicit `return self.client.unload(self)` and replace it with a call to `self.client.unload(self)` followed by a simple `return` statement (or allow the function to finish if no further code remains). This will ensure the function does not return a value where none is expected and keep the function consistent with its intended use and type annotation.

Change only line 54 in file `selfbot/modules/call.py`, replacing:

```python
return self.client.unload(self)
```

with:

```python
self.client.unload(self)
return
```

No imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._