### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/selfbot/modules/call.py
+++ b/selfbot/modules/call.py
@@ -111,11 +111,12 @@ class Call(Module):
             pattern.match(event.content).groupdict().values(),
         )
         if not action:
-            return await event.edit_text(
+            await event.edit_text(
                 fmtstr(
                     "Joined Call IDs", list(await self.client.call.calls), fmtsec(now)
                 )
             )
+            return
 
         if not chat_id:
             chat_id = event.chat.id
@@ -123,9 +124,10 @@ class Call(Module):
             try:
                 chat = await event._client.get_chat(chat_id, False)
             except RPCError as e:
-                return await event.edit_text(
+                await event.edit_text(
                     fmtstr(
                         e.__class__.__name__,
+                return
                         e.MESSAGE.format(value=e.value),
                         fmtsec(now),
                     )


### PR DESCRIPTION
To fix the problem, make all explicit return statements pure side-effect returns (i.e., bare `return` or just allow control flow to exit without returning anything), since the method signature is `-> None` and the return value is ignored. Instead of `return await event.edit_text(...)`, use `await event.edit_text(...)` without the return. Scan all locations where a `return await ...` exists and change them accordingly. Ensure no statements in this method return any value. All control flow should simply exit with no return value, which matches the function's annotation and event handler usage.

Edits required:
- In function `on_message_out`, replace all `return await ...` and `return ...` with just `await ...` (if they are used for side effects).
- Do not change the annotation `-> None`; this is correct.
- Ensure all control flow paths exit without returning a value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._