### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/selfbot/modules/debug.py
+++ b/selfbot/modules/debug.py
@@ -87,9 +87,10 @@ class Debug(Module):
                     html.escape(event.content.markdown).removesuffix("#").rstrip()
                 ),
             )
-            return await event.reply_inline_bot_result(
+            await event.reply_inline_bot_result(
                 res.query_id, res.results[0].id, quote=True
             )
+            return
 
         cmd, msg = await asyncio.gather(
             event.edit_text(


### PR DESCRIPTION
To fix this issue, we should make the return statements consistent in the async handler `on_message_out`, ensuring the function does not mix explicit returns of values (especially of an awaited result) with implicit returns. Since Pyrogram normally ignores handler return values, the best practice is to simply use `await ...` to perform side effects and not return the result. 

Specifically, in line 90, replace:
```py
return await event.reply_inline_bot_result(
    res.query_id, res.results[0].id, quote=True
)
```
with:
```py
await event.reply_inline_bot_result(
    res.query_id, res.results[0].id, quote=True
)
return
```
This way, all explicit returns are return statements (with no value), or the function falls off the end. Alternatively, since execution would otherwise fall to the end, a bare `return` (with no value) can be used for explicit early exits, but no awaitable should be returned directly.

Edit only the relevant region in selfbot/modules/debug.py for `on_message_out`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._